### PR TITLE
add ability to configure trusted root ca [CTDL-229]

### DIFF
--- a/object_store/src/client/mod.rs
+++ b/object_store/src/client/mod.rs
@@ -110,6 +110,8 @@ pub enum ClientConfigKey {
     Timeout,
     /// User-Agent header to be used by this client
     UserAgent,
+    /// PEM-formatted CA certificate
+    RootCa
 }
 
 impl AsRef<str> for ClientConfigKey {
@@ -129,6 +131,7 @@ impl AsRef<str> for ClientConfigKey {
             Self::ProxyUrl => "proxy_url",
             Self::Timeout => "timeout",
             Self::UserAgent => "user_agent",
+            Self::RootCa => "root_ca",
         }
     }
 }
@@ -156,6 +159,7 @@ impl FromStr for ClientConfigKey {
                 store: "HTTP",
                 key: s.into(),
             }),
+            "root_ca" => Ok(Self::RootCa),
         }
     }
 }
@@ -179,6 +183,7 @@ pub struct ClientOptions {
     http2_keep_alive_while_idle: ConfigValue<bool>,
     http1_only: ConfigValue<bool>,
     http2_only: ConfigValue<bool>,
+    root_ca: Option<String>,
 }
 
 impl ClientOptions {
@@ -222,6 +227,9 @@ impl ClientOptions {
             ClientConfigKey::UserAgent => {
                 self.user_agent = Some(ConfigValue::Deferred(value.into()))
             }
+            ClientConfigKey::RootCa => {
+                self.root_ca = Some(value.into())
+            }
         }
         self
     }
@@ -261,6 +269,9 @@ impl ClientOptions {
                 .as_ref()
                 .and_then(|v| v.get().ok())
                 .and_then(|v| v.to_str().ok().map(|s| s.to_string())),
+            ClientConfigKey::RootCa => self
+                .root_ca
+                .clone(),
         }
     }
 
@@ -398,6 +409,13 @@ impl ClientOptions {
         self
     }
 
+
+    /// Set a trusted CA certificate
+    pub fn with_root_ca(mut self, root_ca: impl Into<String>) -> Self {
+        self.root_ca = Some(root_ca.into());
+        self
+    }
+
     /// Get the mime type for the file in `path` to be uploaded
     ///
     /// Gets the file extension from `path`, and returns the
@@ -471,6 +489,13 @@ impl ClientOptions {
 
         if self.allow_insecure.get()? {
             builder = builder.danger_accept_invalid_certs(true)
+        }
+
+        if let Some(cert) = &self.root_ca {
+            let certificate = reqwest::tls::Certificate::from_pem(cert.as_bytes())
+                .map_err(map_client_error)?;
+
+            builder = builder.add_root_certificate(certificate);
         }
 
         builder
@@ -623,6 +648,7 @@ mod tests {
         let proxy_url = "https://fake_proxy_url".to_string();
         let timeout = "95 seconds".to_string();
         let user_agent = "object_store:fake_user_agent".to_string();
+        let root_ca = "fake_certificate".to_string();
 
         let options = HashMap::from([
             ("allow_http", allow_http.clone()),
@@ -648,6 +674,7 @@ mod tests {
             ("proxy_url", proxy_url.clone()),
             ("timeout", timeout.clone()),
             ("user_agent", user_agent.clone()),
+            ("root_ca", root_ca.clone()),
         ]);
 
         let builder = options
@@ -738,6 +765,12 @@ mod tests {
                 .get_config_value(&ClientConfigKey::UserAgent)
                 .unwrap(),
             user_agent
+        );
+        assert_eq!(
+            builder
+                .get_config_value(&ClientConfigKey::RootCa)
+                .unwrap(),
+            root_ca
         );
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Add to ability to configure a trusted self signed CA for object_store client

# Rationale for this change
 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

IBM's COS uses a self signed CA that we need to trust while getting objects via object_store lib

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Add root ca config for object_store client

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
Just optional config addition

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
