### PR TITLE
Bulk RLE encode (fork-only)

### DIFF
--- a/parquet/src/arrow/arrow_writer/levels.rs
+++ b/parquet/src/arrow/arrow_writer/levels.rs
@@ -566,6 +566,9 @@ pub(crate) struct ArrayLevels {
 
     /// The arrow array
     array: ArrayRef,
+
+    #[allow(dead_code)]
+    def_levels_runs: Option<Vec<(i16, usize)>>,
 }
 
 impl PartialEq for ArrayLevels {
@@ -595,6 +598,7 @@ impl ArrayLevels {
             max_def_level,
             max_rep_level,
             array,
+            def_levels_runs: (max_def_level != 0).then(Vec::new),
         }
     }
 
@@ -668,6 +672,7 @@ mod tests {
             max_def_level: 2,
             max_rep_level: 2,
             array: Arc::new(primitives),
+            def_levels_runs: None,
         };
         assert_eq!(&levels[0], &expected);
     }
@@ -688,6 +693,7 @@ mod tests {
             max_def_level: 0,
             max_rep_level: 0,
             array,
+            def_levels_runs: None,
         };
         assert_eq!(&levels[0], &expected_levels);
     }
@@ -714,6 +720,7 @@ mod tests {
             max_def_level: 1,
             max_rep_level: 0,
             array,
+            def_levels_runs: None,
         };
         assert_eq!(&levels[0], &expected_levels);
     }
@@ -748,6 +755,7 @@ mod tests {
             max_def_level: 1,
             max_rep_level: 1,
             array: Arc::new(leaf_array),
+            def_levels_runs: None,
         };
         assert_eq!(&levels[0], &expected_levels);
 
@@ -781,6 +789,7 @@ mod tests {
             max_def_level: 2,
             max_rep_level: 1,
             array: Arc::new(leaf_array),
+            def_levels_runs: None,
         };
         assert_eq!(&levels[0], &expected_levels);
     }
@@ -830,6 +839,7 @@ mod tests {
             max_def_level: 3,
             max_rep_level: 1,
             array: Arc::new(leaf),
+            def_levels_runs: None,
         };
 
         assert_eq!(&levels[0], &expected_levels);
@@ -880,6 +890,7 @@ mod tests {
             max_def_level: 5,
             max_rep_level: 2,
             array: Arc::new(leaf),
+            def_levels_runs: None,
         };
 
         assert_eq!(&levels[0], &expected_levels);
@@ -917,6 +928,7 @@ mod tests {
             max_def_level: 1,
             max_rep_level: 1,
             array: Arc::new(leaf),
+            def_levels_runs: None,
         };
         assert_eq!(&levels[0], &expected_levels);
 
@@ -949,6 +961,7 @@ mod tests {
             max_def_level: 3,
             max_rep_level: 1,
             array: Arc::new(leaf),
+            def_levels_runs: None,
         };
         assert_eq!(&levels[0], &expected_levels);
 
@@ -997,6 +1010,7 @@ mod tests {
             max_def_level: 5,
             max_rep_level: 2,
             array: Arc::new(leaf),
+            def_levels_runs: None,
         };
         assert_eq!(&levels[0], &expected_levels);
     }
@@ -1036,6 +1050,7 @@ mod tests {
             max_def_level: 3,
             max_rep_level: 0,
             array: leaf,
+            def_levels_runs: None,
         };
         assert_eq!(&levels[0], &expected_levels);
     }
@@ -1075,6 +1090,7 @@ mod tests {
             max_def_level: 3,
             max_rep_level: 1,
             array: Arc::new(a_values),
+            def_levels_runs: None,
         };
         assert_eq!(list_level, &expected_level);
     }
@@ -1167,6 +1183,7 @@ mod tests {
             max_def_level: 0,
             max_rep_level: 0,
             array: Arc::new(a),
+            def_levels_runs: None,
         };
         assert_eq!(list_level, &expected_level);
 
@@ -1180,6 +1197,7 @@ mod tests {
             max_def_level: 1,
             max_rep_level: 0,
             array: Arc::new(b),
+            def_levels_runs: None,
         };
         assert_eq!(list_level, &expected_level);
 
@@ -1193,6 +1211,7 @@ mod tests {
             max_def_level: 2,
             max_rep_level: 0,
             array: Arc::new(d),
+            def_levels_runs: None,
         };
         assert_eq!(list_level, &expected_level);
 
@@ -1206,6 +1225,7 @@ mod tests {
             max_def_level: 3,
             max_rep_level: 0,
             array: Arc::new(f),
+            def_levels_runs: None,
         };
         assert_eq!(list_level, &expected_level);
     }
@@ -1312,6 +1332,7 @@ mod tests {
             max_def_level: 1,
             max_rep_level: 1,
             array: map.keys().clone(),
+            def_levels_runs: None,
         };
         assert_eq!(list_level, &expected_level);
 
@@ -1325,6 +1346,7 @@ mod tests {
             max_def_level: 2,
             max_rep_level: 1,
             array: map.values().clone(),
+            def_levels_runs: None,
         };
         assert_eq!(list_level, &expected_level);
     }
@@ -1410,6 +1432,7 @@ mod tests {
             max_def_level: 4,
             max_rep_level: 1,
             array: values,
+            def_levels_runs: None,
         };
 
         assert_eq!(list_level, &expected_level);
@@ -1450,6 +1473,7 @@ mod tests {
             max_def_level: 4,
             max_rep_level: 1,
             array: values,
+            def_levels_runs: None,
         };
 
         assert_eq!(&levels[0], &expected_level);
@@ -1535,6 +1559,7 @@ mod tests {
             max_def_level: 6,
             max_rep_level: 2,
             array: a1_values,
+            def_levels_runs: None,
         };
 
         assert_eq!(&levels[0], &expected_level);
@@ -1546,6 +1571,7 @@ mod tests {
             max_def_level: 4,
             max_rep_level: 1,
             array: a2_values,
+            def_levels_runs: None,
         };
 
         assert_eq!(&levels[1], &expected_level);
@@ -1584,6 +1610,7 @@ mod tests {
             max_def_level: 3,
             max_rep_level: 1,
             array: values,
+            def_levels_runs: None,
         };
         assert_eq!(list_level, &expected_level);
     }
@@ -1734,6 +1761,7 @@ mod tests {
             max_def_level: 4,
             max_rep_level: 1,
             array: values_a,
+            def_levels_runs: None,
         };
         // [[{b: 2}, null], null, [null, null], [{b: 3}, {b: 4}]]
         let expected_b = ArrayLevels {
@@ -1743,6 +1771,7 @@ mod tests {
             max_def_level: 3,
             max_rep_level: 1,
             array: values_b,
+            def_levels_runs: None,
         };
 
         assert_eq!(a_levels, &expected_a);
@@ -1774,6 +1803,7 @@ mod tests {
             max_def_level: 3,
             max_rep_level: 1,
             array: values,
+            def_levels_runs: None,
         };
         assert_eq!(list_level, &expected_level);
     }
@@ -1809,6 +1839,7 @@ mod tests {
             max_def_level: 5,
             max_rep_level: 2,
             array: values,
+            def_levels_runs: None,
         };
 
         assert_eq!(levels[0], expected_level);
@@ -1839,6 +1870,7 @@ mod tests {
             max_def_level: 1,
             max_rep_level: 0,
             array: Arc::new(dict),
+            def_levels_runs: None,
         };
         assert_eq!(levels[0], expected_level);
     }

--- a/parquet/src/column/writer/mod.rs
+++ b/parquet/src/column/writer/mod.rs
@@ -360,6 +360,9 @@ pub struct GenericColumnWriter<'a, E: ColumnValueEncoder> {
     data_page_boundary_descending: bool,
     /// (min, max)
     last_non_null_data_page_min_max: Option<(E::T, E::T)>,
+
+    def_levels_runs_sink: Vec<(i16, usize)>,
+    num_levels: usize,
 }
 
 impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
@@ -425,6 +428,8 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
             data_page_boundary_ascending: true,
             data_page_boundary_descending: true,
             last_non_null_data_page_min_max: None,
+            def_levels_runs_sink: vec![],
+            num_levels: 0,
         }
     }
 
@@ -439,6 +444,9 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
         max: Option<&E::T>,
         distinct_count: Option<u64>,
     ) -> Result<usize> {
+        if !self.def_levels_runs_sink.is_empty() {
+            self.add_data_page()?;
+        }
         // Check if number of definition levels is the same as number of repetition levels.
         if let (Some(def), Some(rep)) = (def_levels, rep_levels) {
             if def.len() != rep.len() {
@@ -553,6 +561,112 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
             max,
             distinct_count,
         )
+    }
+
+    /// Write a batch of values with a uniform definition level (bulk RLE optimization).
+    pub fn write_def_level_range_batch(
+        &mut self,
+        values: &E::Values,
+        def_level: i16,
+        num_levels: usize,
+        min: Option<&E::T>,
+        max: Option<&E::T>,
+        distinct_count: Option<u64>,
+    ) -> Result<usize> {
+        if self.descr.max_rep_level() > 0 {
+            return Err(general_err!(
+                "Cannot write def level range when rep level > 0",
+            ));
+        }
+        if self.statistics_enabled == EnabledStatistics::Chunk {
+            match (min, max) {
+                (Some(min), Some(max)) => {
+                    update_min(&self.descr, min, &mut self.column_metrics.min_column_value);
+                    update_max(&self.descr, max, &mut self.column_metrics.max_column_value);
+                }
+                (None, Some(_)) | (Some(_), None) => {
+                    panic!("min/max should be both set or both None")
+                }
+                (None, None) => {}
+            };
+        }
+
+        // We can only set the distinct count if there are no other writes
+        if self.encoder.num_values() == 0 {
+            self.column_metrics.column_distinct_count = distinct_count;
+        } else {
+            self.column_metrics.column_distinct_count = None;
+        }
+
+        let mut values_offset = 0;
+        let mut levels_offset = 0;
+        let base_batch_size = self.props.write_batch_size();
+        while levels_offset < num_levels {
+            let end_offset = num_levels.min(levels_offset + base_batch_size);
+
+            values_offset += self.write_mini_batch_with_def_level(
+                values,
+                values_offset,
+                None,
+                end_offset - levels_offset,
+                def_level,
+            )?;
+            levels_offset = end_offset;
+        }
+
+        // Return total number of values processed.
+        Ok(values_offset)
+    }
+
+    fn write_mini_batch_with_def_level(
+        &mut self,
+        values: &E::Values,
+        values_offset: usize,
+        value_indices: Option<&[usize]>,
+        num_levels: usize,
+        def_level: i16,
+    ) -> Result<usize> {
+        if !self.def_levels_sink.is_empty() {
+            self.add_data_page()?;
+        }
+        if let Some((last_def_level, last_count)) = self.def_levels_runs_sink.last_mut() {
+            if *last_def_level == def_level {
+                *last_count += num_levels;
+            } else {
+                self.def_levels_runs_sink.push((def_level, num_levels));
+            }
+        } else {
+            self.def_levels_runs_sink.push((def_level, num_levels));
+        }
+        self.num_levels += num_levels;
+        let values_to_write = if def_level == self.descr.max_def_level() {
+            num_levels
+        } else {
+            self.page_metrics.num_page_nulls += num_levels as u64;
+            0
+        };
+
+        self.page_metrics.num_buffered_rows += num_levels as u32;
+
+        match value_indices {
+            Some(indices) => {
+                let indices = &indices[values_offset..values_offset + values_to_write];
+                self.encoder.write_gather(values, indices)?;
+            }
+            None => self.encoder.write(values, values_offset, values_to_write)?,
+        }
+
+        self.page_metrics.num_buffered_values += num_levels as u32;
+
+        if self.should_add_data_page() {
+            self.add_data_page()?;
+        }
+
+        if self.should_dict_fallback() {
+            self.dict_fallback()?;
+        }
+
+        Ok(values_to_write)
     }
 
     /// Returns the estimated total memory usage.
@@ -1008,13 +1122,21 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
                 }
 
                 if max_def_level > 0 {
-                    buffer.extend_from_slice(
+                    let encoded_levels = if self.def_levels_runs_sink.is_empty() {
                         &self.encode_levels_v1(
                             Encoding::RLE,
                             &self.def_levels_sink[..],
                             max_def_level,
-                        )[..],
-                    );
+                        )[..]
+                    } else {
+                        &self.encode_levels_v1_bulk(
+                            Encoding::RLE,
+                            &self.def_levels_runs_sink[..],
+                            self.num_levels,
+                            max_def_level,
+                        )[..]
+                    };
+                    buffer.extend_from_slice(encoded_levels);
                 }
 
                 buffer.extend_from_slice(&values_data.buf);
@@ -1095,6 +1217,8 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
         self.rep_levels_sink.clear();
         self.def_levels_sink.clear();
         self.page_metrics.new_page();
+        self.def_levels_runs_sink.clear();
+        self.num_levels = 0;
 
         Ok(())
     }
@@ -1217,6 +1341,20 @@ impl<'a, E: ColumnValueEncoder> GenericColumnWriter<'a, E> {
     fn encode_levels_v1(&self, encoding: Encoding, levels: &[i16], max_level: i16) -> Vec<u8> {
         let mut encoder = LevelEncoder::v1(encoding, max_level, levels.len());
         encoder.put(levels);
+        encoder.consume()
+    }
+
+    /// Encodes definition or repetition levels for Data Page v1.
+    #[inline]
+    fn encode_levels_v1_bulk(
+        &self,
+        encoding: Encoding,
+        level_runs: &[(i16, usize)],
+        num_levels: usize,
+        max_level: i16,
+    ) -> Vec<u8> {
+        let mut encoder = LevelEncoder::v1(encoding, max_level, num_levels);
+        encoder.put_bulk(level_runs);
         encoder.consume()
     }
 

--- a/parquet/src/encodings/levels.rs
+++ b/parquet/src/encodings/levels.rs
@@ -108,6 +108,28 @@ impl LevelEncoder {
         num_encoded
     }
 
+    /// Put/encode levels vector into this level encoder.
+    /// Returns number of encoded values that are less than or equal to length of the
+    /// input buffer.
+    /// Write multiple level runs as `(level, count)` pairs.
+    #[inline]
+    pub fn put_bulk(&mut self, runs: &[(i16, usize)]) -> usize {
+        let mut num_encoded = 0;
+        match *self {
+            LevelEncoder::Rle(ref mut encoder) | LevelEncoder::RleV2(ref mut encoder) => {
+                for &(value, count) in runs {
+                    encoder.put_bulk(value as u64, count);
+                    num_encoded += count;
+                }
+                encoder.flush();
+            }
+            LevelEncoder::BitPacked(_, _) => {
+                unimplemented!()
+            }
+        }
+        num_encoded
+    }
+
     /// Finalizes level encoder, flush all intermediate buffers and return resulting
     /// encoded buffer. Returned buffer is already truncated to encoded bytes only.
     #[inline]

--- a/parquet/src/encodings/rle.rs
+++ b/parquet/src/encodings/rle.rs
@@ -151,6 +151,96 @@ impl RleEncoder {
         }
     }
 
+    /// Encode a single value repeated `count` times.
+    #[inline]
+    pub fn put_bulk(&mut self, value: u64, count: usize) {
+        assert!(count > 0, "Count must be positive");
+        let remaining = 8 - self.num_buffered_values;
+        if self.current_value == value {
+            if self.repeat_count >= 8 {
+                self.repeat_count += count;
+                return;
+            }
+            let n = remaining.min(count);
+            for _ in 0..n {
+                self.buffered_values[self.num_buffered_values] = value;
+                self.num_buffered_values += 1;
+                self.repeat_count += 1;
+            }
+            if self.num_buffered_values == 8 {
+                assert_eq!(self.bit_packed_count % 8, 0);
+                self.flush_buffered_values();
+                if count > n {
+                    let mut remaining_run = count - n;
+                    // Fill buffer
+                    for _ in 0..remaining_run.min(8) {
+                        self.repeat_count += 1;
+                        remaining_run -= 1;
+                        if self.repeat_count > 8 {
+                            break;
+                        }
+                        self.buffered_values[self.num_buffered_values] = value;
+                        self.num_buffered_values += 1;
+                    }
+                    if self.num_buffered_values == 8 && self.repeat_count <= 8 {
+                        // Buffered values are full. Flush them.
+                        assert_eq!(self.bit_packed_count % 8, 0);
+                        self.flush_buffered_values();
+                    }
+
+                    self.repeat_count += remaining_run;
+                }
+            }
+        } else {
+            if self.repeat_count >= 8 {
+                // The current RLE run has ended and we've gathered enough. Flush first.
+                assert_eq!(
+                    self.bit_packed_count, 0,
+                    "rc = {}, value = {}, num_buffered = {}, c = {count}, {:?}",
+                    self.repeat_count, value, self.num_buffered_values, self.buffered_values
+                );
+                self.flush_rle_run();
+            }
+            self.current_value = value;
+            let n = remaining.min(count);
+            self.repeat_count = 0;
+            for _ in 0..n {
+                self.buffered_values[self.num_buffered_values] = value;
+                self.num_buffered_values += 1;
+                self.repeat_count += 1;
+            }
+            if self.num_buffered_values == 8 {
+                let mut new_count = count;
+                if self.repeat_count < 8 {
+                    new_count = count - self.repeat_count;
+                }
+                // Buffered values are full. Flush them.
+                assert_eq!(self.bit_packed_count % 8, 0);
+                self.flush_buffered_values();
+                if count > n {
+                    if self.repeat_count <= 8 {
+                        for _ in 0..(count - n).min(8) {
+                            self.repeat_count += 1;
+                            if self.repeat_count > 8 {
+                                break;
+                            }
+                            self.buffered_values[self.num_buffered_values] = value;
+                            self.num_buffered_values += 1;
+                        }
+                        if self.num_buffered_values == 8 && self.repeat_count <= 8 {
+                            // Buffered values are full. Flush them.
+                            assert_eq!(self.bit_packed_count % 8, 0);
+                            self.flush_buffered_values();
+                        }
+                    }
+                    self.repeat_count = new_count;
+                }
+            } else if count > 8 {
+                self.repeat_count = count;
+            }
+        }
+    }
+
     #[inline]
     #[allow(unused)]
     pub fn buffer(&self) -> &[u8] {


### PR DESCRIPTION
Backport @joroKr21 's RLE fix to v55 so we're not releasing net new node when we go to DF48